### PR TITLE
Add link to the repo in R

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ root@kali:~# python3 ban_geocoder.py --lon 2.31698 --lat 48.870675 --csv
 55 Rue du Faubourg Saint-Honoré 75008 Paris
 55;Rue du Faubourg Saint-Honoré;75008;Paris;2.31698, 48.870675
 ```
+## See also
+* [BanR](https://github.com/joelgombin/banR) : R client for the BAN API 


### PR DESCRIPTION
I think it's good for discoverability to add a link to BanR since it is very similar to BAN-Geocoder